### PR TITLE
Adicionar aplicação de exemplo com conversão de temperatura + Readme atualizado

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ func main() {
 }
 ```
 
+Aplicação de exemplo
+----
+O repositório inclui uma aplicação de exemplo (`app.go`) que demonstra a conversão de temperaturas entre as escalas Celsius e Fahrenheit.
+
+Para executar a aplicação, forneça um valor de temperatura como parâmetro:
+
+```
+go run ./app 100
+```
+
+Saída esperada:
+```
+100°C = 212°F
+100°F = 37.78°C
+```
+
 Outras linguagens?
 ----
 Versões da biblioteca *tempconv* para outras linguagens:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,45 @@ Saída esperada:
 100°F = 37.78°C
 ```
 
+O código da aplicação:
+
+```go
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/ufla-gcc259/aula-git-parte-2/tempconv"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Uso: go run ./app <temperatura>")
+		os.Exit(1)
+	}
+
+	// Converte o argumento para float64
+	temp, err := strconv.ParseFloat(os.Args[1], 64)
+	if err != nil {
+		fmt.Printf("Erro ao converter %q: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
+
+	// Converte e exibe a temperatura nas diferentes escalas
+	c := tempconv.Celsius(temp)
+	f := tempconv.Fahrenheit(temp)
+
+	// Para a saída em Celsius, formata com duas casas decimais
+	cToF := tempconv.CToF(c)
+	fToC := tempconv.FToC(f)
+	
+	fmt.Printf("%.0f°C = %.0f°F\n", c, cToF)
+	fmt.Printf("%.0f°F = %.2f°C\n", f, fToC)
+}
+```
+
 Outras linguagens?
 ----
 Versões da biblioteca *tempconv* para outras linguagens:

--- a/app/app.go
+++ b/app/app.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/ufla-gcc259/aula-git-parte-2/tempconv"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Println("Uso: go run ./app <temperatura>")
+		os.Exit(1)
+	}
+
+	// Converte o argumento para float64
+	temp, err := strconv.ParseFloat(os.Args[1], 64)
+	if err != nil {
+		fmt.Printf("Erro ao converter %q: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
+
+	// Converte e exibe a temperatura nas diferentes escalas
+	c := tempconv.Celsius(temp)
+	f := tempconv.Fahrenheit(temp)
+
+	// Para a saída em Celsius, formata com duas casas decimais
+	cToF := tempconv.CToF(c)
+	fToC := tempconv.FToC(f)
+
+	fmt.Printf("%.0f°C = %.0f°F\n", c, cToF)
+	fmt.Printf("%.0f°F = %.2f°C\n", f, fToC)
+}


### PR DESCRIPTION
Esta PR adiciona uma aplicação de exemplo que demonstra o uso da biblioteca tempconv. A aplicação recebe um valor de temperatura via linha de comando e exibe sua conversão entre as escalas Celsius e Fahrenheit com formatação apropriada.

Mudanças implementadas
- Criação do arquivo app.go com aplicação de exemplo que:
  - Aceita um parâmetro numérico via linha de comando
  - Converte o valor entre Celsius e Fahrenheit
  - Exibe os resultados com formatação adequada 
- Atualização do README.md para incluir:
  - Instruções de uso da aplicação de exemplo
  - Saída esperada com a formatação correta
  - Exemplo de código