### PR TITLE
Considerar escala Kelvin

### DIFF
--- a/tempconv/tempconv.go
+++ b/tempconv/tempconv.go
@@ -4,6 +4,7 @@ import "fmt"
 
 type Celsius float64
 type Fahrenheit float64
+type Kelvin float64
 
 const (
 	// AbsoluteZeroC representa a temperatura zero absoluto em Celsius
@@ -22,8 +23,23 @@ func (c Celsius) String() string { return fmt.Sprintf("%g°C", c) }
 // String imprime uma temperatura 'n' em Fahrenheit no formato n°F
 func (f Fahrenheit) String() string { return fmt.Sprintf("%g°F", f) }
 
+// String imprime uma temperatura 'n' em Kelvin no formato nK
+func (k Kelvin) String() string { return fmt.Sprintf("%gK", k) }
+
 // CToF converte uma temperatura em Celsius para Fahrenheit
 func CToF(c Celsius) Fahrenheit { return Fahrenheit(c*9/5 + 32) }
 
 // FToC converte uma temperatura em Fahrenheit para Celsius
 func FToC(f Fahrenheit) Celsius { return Celsius((f - 32) * 5 / 9) }
+
+// CToK converte uma temperatura em Celsius para Kelvin
+func CToK(c Celsius) Kelvin { return Kelvin(c + 273.15) }
+
+// KToC converte uma temperatura em Kelvin para Celsius
+func KToC(k Kelvin) Celsius { return Celsius(k - 273.15) }
+
+// FToK converte uma temperatura em Fahrenheit para Kelvin
+func FToK(f Fahrenheit) Kelvin { return CToK(FToC(f)) }
+
+// KToF converte uma temperatura em Kelvin para Fahrenheit
+func KToF(k Kelvin) Fahrenheit { return CToF(KToC(k)) }


### PR DESCRIPTION
Adição do tipo "Kelvin" com suas respectivas funções de conversões para Celsius e Fahrenheit à biblioteca.